### PR TITLE
fix: check the user's state when handling a request

### DIFF
--- a/server/src/uds/REST/handlers.py
+++ b/server/src/uds/REST/handlers.py
@@ -42,6 +42,7 @@ from uds.core.auths.auth import getRootUser
 from uds.core.util import net
 from uds.models import Authenticator, User
 from uds.core.managers.crypto import CryptoManager
+from uds.core.util.state import State
 
 from .exceptions import AccessDenied
 
@@ -151,7 +152,11 @@ class Handler:
                 # Maybe the user was deleted, so access is denied
                 raise AccessDenied() from e
         else:
-            self._user = User()  # Empty user for non authenticated handlers
+            # self._user = User()  # Empty user for non authenticated handlers
+            raise AccessDenied()
+
+        if self._user and self._user.state != State.ACTIVE:
+            raise AccessDenied()
 
     def headers(self) -> dict[str, str]:
         """

--- a/server/src/uds/middleware/request.py
+++ b/server/src/uds/middleware/request.py
@@ -47,6 +47,8 @@ from uds.core.auths.auth import (
     webLogout,
 )
 from uds.models import User
+from uds.core.util.state import State
+
 
 from . import builder
 
@@ -123,6 +125,8 @@ def _get_user(request: 'ExtendedHttpRequest') -> None:
                 user = User.objects.get(pk=user_id)
         except User.DoesNotExist:
             user = None
+    if user and user.state != State.ACTIVE:
+        user = None
 
     logger.debug('User at Middleware: %s %s', user_id, user)
 


### PR DESCRIPTION
Hello @dkmstr ,

I recently performed a penetration test (pentest) on the system and discovered a bug in session management. Specifically, when a user is inactive, they can still make requests to the system if their session has not been destroyed.

To fix this bug, I added a user state check to the request middleware and handler. Please review and confirm that it works as expected.